### PR TITLE
github: Add shellcheck and yapf workflows

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,14 @@
+name: shellcheck
+
+on:
+  workflow_call:
+
+jobs:
+  shellcheck:
+    name: 'shellcheck'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: shellcheck
+        uses: bewuethr/shellcheck-action@v2

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -1,0 +1,14 @@
+name: yapf
+
+on:
+  workflow_call:
+
+jobs:
+  yapf:
+    name: 'yapf'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: yapf
+        uses: AlexanderMelde/yapf-action@v1.0


### PR DESCRIPTION
While these are short workflows, they are used all over our repositories
and they have versions in them, meaning that if we ever need to upgrade
them, we will have to do them everywhere. Add them here for easy reuse.