### PR TITLE
workflows: Bump actions/checkout to v3

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: shellcheck
         uses: bewuethr/shellcheck-action@v2

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: shfmt
         uses: ClangBuiltLinux/actions-workflows/shfmt@main

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: yapf
         uses: AlexanderMelde/yapf-action@v1.0


### PR DESCRIPTION
Link: https://github.com/actions/checkout/releases/tag/v3.0.0
