### PR TITLE
disable pylint W1509 subprocess-popen-preexec-fn

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -51,8 +51,9 @@ jobs:
       # R0913: too-many-arguments
       # R0914: too-many-locals
       # R0915: too-many-statements
+      # W1509: subprocess-popen-preexec-fn
       - name: pylint
-        run: pylint --disable C0114,C0115,C0116,C0301,C0302,R0902,R0903,R0911,R0912,R0913,R0914,R0915 --jobs $(nproc) $(git ls-files '*.py')
+        run: pylint --disable C0114,C0115,C0116,C0301,C0302,R0902,R0903,R0911,R0912,R0913,R0914,R0915,W1509 --jobs $(nproc) $(git ls-files '*.py')
 
       - name: yapf
         run: yapf --diff --recursive $GITHUB_WORKSPACE


### PR DESCRIPTION
I'm not sure how to work around

  boot-qemu.py:768:17: W1509: Using preexec_fn keyword which may be unsafe in the presence of threads (subprocess-popen-preexec-fn)

For python 3.10.8.  I might be able to use process_group=1 in the subprocess.Popen constructor, but seems it's only available in python 3.11+.

Link: https://github.com/ClangBuiltLinux/boot-utils/pull/87