### PR TITLE
workflows: python_lint: Add support for linting with ruff

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -20,18 +20,31 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: flake8
-        uses: py-actions/flake8@v2
-        with:
-          ignore: "E501"
-
-      - name: Install pylint and yapf
+      - name: Install dependencies
         run: |
           pip install --upgrade pip
           pip install pylint yapf
+          if git ls-files | grep -Fq ruff.toml; then
+            pip install ruff
+            echo "ruff=true" >>$GITHUB_ENV
+          else
+            echo "ruff=false" >>$GITHUB_ENV
+          fi
           if test -e requirements.txt; then
             pip install -r requirements.txt
           fi
+
+      - name: ruff
+        run: ruff check .
+        if: ${{ env.ruff == 'true' }}
+
+      - name: flake8
+        # ruff can replace flake8 with a proper configuration so do not bother
+        # running this step if ruff has already run.
+        if: ${{ env.ruff == 'false' }}
+        uses: py-actions/flake8@v2
+        with:
+          ignore: "E501"
 
       # This is an opinionated list of disabled warnings.
       # It potentially makes sense to eventually remove


### PR DESCRIPTION
[`ruff`](https://github.com/charliermarsh/ruff) is a fast Python linter written in Rust. Add support for linting with `ruff` if a `ruff.toml` file is found within a repository. This allows projects to have a set of warnings per project.

`ruff` can basically replace `flake8` with a proper configuration, so do not bother running `flake8` if `ruff` is run.
