### PR TITLE
python_lint: Disable pylint R0801

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -57,6 +57,7 @@ jobs:
       # C0116: missing-function-docstring
       # C0301: line-too-long
       # C0302: too-many-lines
+      # R0801: duplicate-code
       # R0902: too-many-instance-attributes
       # R0903: too-few-public-methods
       # R0911: too-many-returns
@@ -66,7 +67,7 @@ jobs:
       # R0915: too-many-statements
       # W1509: subprocess-popen-preexec-fn
       - name: pylint
-        run: pylint --disable C0114,C0115,C0116,C0301,C0302,R0902,R0903,R0911,R0912,R0913,R0914,R0915,W1509 --jobs $(nproc) $(git ls-files '*.py')
+        run: pylint --disable C0114,C0115,C0116,C0301,C0302,R0801,R0902,R0903,R0911,R0912,R0913,R0914,R0915,W1509 --jobs $(nproc) $(git ls-files '*.py')
 
       - name: yapf
         run: yapf --diff --recursive $GITHUB_WORKSPACE


### PR DESCRIPTION
While the intent of this warning is admirable, it ends up triggering on
really dumb things, like the '# DO NOT MODIFY MANUALLY' prints that are
added to both TuxSuite and GitHub Actions workflow files in
continuous-integration2.
