### PR TITLE
workflows: python_lint: Update setup-python action to v5

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
 


### PR DESCRIPTION
This is needed to avoid warnings about NodeJS 16 being deprecated.
