### PR TITLE
workflows: python_lint: Add ability to run ty

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -6,6 +6,9 @@ on:
       python_version:
         required: true
         type: string
+      ty:
+        description: 'Run ty on Python code'
+        type: boolean
 
 jobs:
   python_linting:
@@ -28,6 +31,10 @@ jobs:
 
       - name: ruff format
         run: uvx ruff format --diff .
+
+      - name: ty check
+        if:  ${{ inputs.ty }}
+        run: uvx ty check .
 
       # This is an opinionated list of disabled warnings.
       # It potentially makes sense to eventually remove


### PR DESCRIPTION
`ty` is a fast Python type checker, made the same people who created `ruff` and `uv`. Allow projects to opt-in to this type checking if they have added type annotations.
