### PR TITLE
workflows: python_lint: Bump setup-uv to v8.0.0

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: ruff check
         run: uvx ruff check .


### PR DESCRIPTION
This workflow now requires the full version tag.

Link: https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0
